### PR TITLE
Allow the GraphiQL version to be specified

### DIFF
--- a/lib/Plack/App/GraphQL.pm
+++ b/lib/Plack/App/GraphQL.pm
@@ -130,7 +130,7 @@ has ui_template => (
 
   sub _build_ui_template {
     my $self = shift;
-    $self->ui_template_class->new(json_encoder => $self->json_encoder);
+    $self->ui_template_class->new(json_encoder => $self->json_encoder, graphiql_version => $self->graphiql_version);
   }
 
 has graphiql => (
@@ -140,6 +140,14 @@ has graphiql => (
 );
 
   sub DEFAULT_GRAPHIQL { our $DEFAULT_GRAPHIQL ||= 0 }
+
+has graphiql_version => (
+  is => 'ro',
+  required => 1,
+  builder => 'DEFAULT_GRAPHIQL_VERSION',
+);
+
+  sub DEFAULT_GRAPHIQL_VERSION { our $DEFAULT_GRAPHIQL_VERSION ||= 'latest' }
 
 has json_encoder => (
   is => 'ro',
@@ -332,6 +340,9 @@ Plack::App::GraphQL - Serve GraphQL from Plack / PSGI
 
 =begin markdown
 
+
+https://travis-ci.org/jjn1056/Plack-App-GraphQL
+
 # PROJECT STATUS
 
 [![Build Status](https://travis-ci.org/jjn1056/Plack-App-GraphQL.svg?branch=master)](https://travis-ci.org/jjn1056/Plack-App-GraphQL)
@@ -437,6 +448,12 @@ The URI path part that is associated with the graphql API endpoint.  Often this 
 Default is L<Plack::App::GraphQL::Context>.  This is an object that is passed as the 'context'
 argument to your field resolvers.  You might wish to subclass this to add additional useful
 methods such as simple access to a user object (if you you authentication for example).
+
+=head2 graphiql_version
+
+String that defaults to 'latest'.  This allows you to specify the graphiql version to use.
+
+B<NOTE> Setting this does not enable GraphiQL.
 
 =head2 graphiql
 

--- a/lib/Plack/App/GraphQL/UITemplate.pm
+++ b/lib/Plack/App/GraphQL/UITemplate.pm
@@ -35,6 +35,12 @@ has json_encoder => (
   },
 );
 
+has graphiql_version => (
+  is => 'ro',
+  required => 1,
+  default => 'latest',
+);
+
 sub safe_serialize {
   my ($self, $data) = @_;
   if($data) {
@@ -56,7 +62,7 @@ sub process {
 sub args_from_query {
   my ($self, $query) = @_;
   return my %args = (
-    graphiql_version => 'latest',
+    graphiql_version => $self->graphiql_version,
     queryString      => $self->safe_serialize( $query->{'query'} ),
     operationName    => $self->safe_serialize( $query->{'operationName'} ),
     resultString     => $self->safe_serialize( $query->{'result'} ),


### PR DESCRIPTION
The "latest" minified version of the GraphiQL js code is causing an
error which does not allow the page load.  Using an earlier version
(for example '0.14.2') allows it to work.  This change allows the app
to pass the version (defaulting to 'latest') to the template
processing code.